### PR TITLE
added cache accounts cron job deployment to happen after service deploy

### DIFF
--- a/files/cron.d/cache_accounts
+++ b/files/cron.d/cache_accounts
@@ -1,0 +1,2 @@
+# Cron hourly to fetch account and account-key assertions from store
+@hourly root serial-vault-admin account cache


### PR DESCRIPTION
Besides, it is corrected the way of setting permissions to files, prefixing wiht 0o to prevent python taking wildcard as decimal instead of octal
Corrected systemctl daemon-reload, which was not happening due to an error in code